### PR TITLE
Fix python 3.8 deprecation warning

### DIFF
--- a/autoload/conque_gdb/conque_gdb.py
+++ b/autoload/conque_gdb/conque_gdb.py
@@ -1,4 +1,8 @@
-import re, collections
+import re
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 # Marks that a breakpoint has been hit
 GDB_BREAK_MARK = '\x1a\x1a'
@@ -36,7 +40,7 @@ class RegisteredBreakpoint:
     def __str__(self):
         return self.filename + ':' + self.lineno + ',' + self.enabled
 
-class RegisteredBpDict(collections.MutableMapping):
+class RegisteredBpDict(MutableMapping):
     def __init__(self):
         self.r_breaks = dict()
         self.lookups = dict()
@@ -102,7 +106,7 @@ class ConqueGdb(Conque):
     # Breakpoints which have been registered to exist
     registered_breakpoints = RegisteredBpDict()
 
-    # Mapping from linenumber + filename to a tuple containing the id of the sign 
+    # Mapping from linenumber + filename to a tuple containing the id of the sign
     # placed there and whether the breakpoint is enabled ('y') or disabled ('n')
     lookup_sign_ids = dict()
 


### PR DESCRIPTION
Since python 3.8 opening vim with installed Conque-GDB raises the next error:

```
> vim                   
Error detected while processing function conque_gdb#load_python:
line    6:
/home/felixoid/.dotfiles/tag-vim/vim/plugged/Conque-GDB/autoload/conque_gdb/conque_gdb.py:39: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  class RegisteredBpDict(collections.MutableMapping):
```

This patch fixes it for python3 and should be still compatible with python2